### PR TITLE
Fix auto alias for devices and actions

### DIFF
--- a/65_HiveHome_Action.pm
+++ b/65_HiveHome_Action.pm
@@ -4,7 +4,7 @@ package main;
 use strict;
 use warnings;
 
-sub HiveHome_Action_Initialize
+sub HiveHome_Action_Initialize($)
 {
 	my ($hash) = @_;
 
@@ -27,13 +27,13 @@ sub HiveHome_Action_Initialize
 	return undef;
 }
 
-sub HiveHome_Action_CheckIODev
+sub HiveHome_Action_CheckIODev($)
 {
 	my $hash = shift;
 	return !defined($hash->{IODev}) || ($hash->{IODev}{TYPE} ne "HiveHome_Action");
 }
 
-sub HiveHome_Action_Define
+sub HiveHome_Action_Define($$)
 {
 	my ($hash, $def) = @_;
 
@@ -98,7 +98,7 @@ sub HiveHome_Action_Define
 	return undef;
 }
 
-sub HiveHome_Action_Undefine
+sub HiveHome_Action_Undefine($$)
 {
 	my ($hash,$arg) = @_;
 
@@ -111,14 +111,14 @@ sub HiveHome_Action_Undefine
 	return undef;
 }
 
-sub HiveHome_Action_SetAlias
+sub HiveHome_Action_SetAlias($$)
 {
 	my ($hash, $name) = @_;
 
 	Log(5, "HiveHome_Action_SetAlias: enter");
 
 	my $attVal = AttrVal($name, 'autoAlias', undef);
-	if (defined($attVal) && $attVal eq '1' && 1 == $init_done)
+	if (defined($attVal) && $attVal eq '1')
 	{
 		fhem("attr ${name} alias ".InternalVal($name, 'name', ''));
 	}	
@@ -126,7 +126,7 @@ sub HiveHome_Action_SetAlias
 	return undef;
 }
 
-sub HiveHome_Action_Attr
+sub HiveHome_Action_Attr($$$$)
 {
     my ( $cmd, $name, $attrName, $attrVal ) = @_;
     my $hash = $defs{$name};
@@ -135,7 +135,7 @@ sub HiveHome_Action_Attr
 
 	Log(4, "HiveHome_Action_Attr: Cmd: ${cmd}, Attribute: ${attrName}, value: ${attrVal}");
 
-	if ($attrName eq 'autoAlias' && 1 == $init_done) 
+	if ($attrName eq 'autoAlias') 
 	{
         if ($cmd eq 'set')
 		{
@@ -163,7 +163,7 @@ sub HiveHome_Action_Attr
     return undef;		
 }
 
-sub HiveHome_Action_Set
+sub HiveHome_Action_Set($$$$)
 {
 	my ($hash,$name,$cmd,@args) = @_;
 
@@ -179,7 +179,7 @@ sub HiveHome_Action_Set
 	return $ret;
 }
 
-sub HiveHome_Action_Parse
+sub HiveHome_Action_Parse($$$)
 {
 	my ($hash, $msg, $device) = @_;
 	my ($name, $type, $id, $nodeString) = split(",", $msg, 4);
@@ -213,7 +213,7 @@ sub HiveHome_Action_Parse
 
 		$myState = $node->{enabled} ? "Enabled" : "Disabled";
 
-		HiveHome_Action_SetAlias($shash, $name);
+		HiveHome_Action_SetAlias($shash, $shash->{NAME});
 	}
 
 	$shash->{STATE} = $myState;

--- a/65_HiveHome_Device.pm
+++ b/65_HiveHome_Device.pm
@@ -4,7 +4,7 @@ package main;
 use strict;
 use warnings;
 
-sub HiveHome_Device_Initialize
+sub HiveHome_Device_Initialize($)
 {
 	my ($hash) = @_;
 
@@ -27,7 +27,7 @@ sub HiveHome_Device_Initialize
 	return undef;
 }
 
-sub HiveHome_Device_CheckIODev
+sub HiveHome_Device_CheckIODev($)
 {
 	my $hash = shift;
 	return !defined($hash->{IODev}) || ($hash->{IODev}{TYPE} ne "HiveHome_Device");
@@ -125,7 +125,7 @@ sub HiveHome_Device_Define
 	return undef;
 }
 
-sub HiveHome_Device_Undefine
+sub HiveHome_Device_Undefine($$)
 {
 	my ($hash,$arg) = @_;
 
@@ -138,23 +138,23 @@ sub HiveHome_Device_Undefine
 	return undef;
 }
 
-sub HiveHome_Device_SetAlias
+sub HiveHome_Device_SetAlias($$)
 {
 	my ($hash, $name) = @_;
 
 	Log(5, "HiveHome_Device_SetAlias: enter");
 
 	my $attVal = AttrVal($name, 'autoAlias', undef);
-	if (defined($attVal) && $attVal eq '1' && 1 == $init_done)
+	if (defined($attVal) && $attVal eq '1')
 	{
-		fhem("attr ${name} alias ".InternalVal($name, 'name', '').' '.InternalVal($name, 'productType', ''));
+		fhem("attr ${name} alias ".InternalVal($name, 'name', '').' '.InternalVal($name, 'deviceType', ''));
 	}
 
 	Log(5, "HiveHome_Device_SetAlias: exit");
 	return undef;
 }
 
-sub HiveHome_Device_Attr
+sub HiveHome_Device_Attr($$$$)
 {
     my ( $cmd, $name, $attrName, $attrVal ) = @_;
     my $hash = $defs{$name};
@@ -163,7 +163,7 @@ sub HiveHome_Device_Attr
 
 	Log(4, "HiveHome_Device_Attr: Cmd: ${cmd}, Attribute: ${attrName}, value: ${attrVal}");
 
-	if ($attrName eq 'autoAlias' && 1 == $init_done) 
+	if ($attrName eq 'autoAlias') 
 	{
         if ($cmd eq 'set')
 		{
@@ -191,7 +191,7 @@ sub HiveHome_Device_Attr
     return undef;		
 }
 
-sub HiveHome_Device_Set
+sub HiveHome_Device_Set($$$$)
 {
 	my ($hash,$name,$cmd,@args) = @_;
 
@@ -207,7 +207,7 @@ sub HiveHome_Device_Set
 	return $ret;
 }
 
-sub HiveHome_Device_Parse
+sub HiveHome_Device_Parse($$$)
 {
 	my ($hash, $msg, $device) = @_;
 	my ($name, $type, $id, $nodeString) = split(",", $msg, 4);
@@ -305,7 +305,7 @@ sub HiveHome_Device_Parse
 		readingsEndUpdate($shash, 1);
 
 
-		HiveHome_Device_SetAlias($shash, $name);
+		HiveHome_Device_SetAlias($shash, $shash->{NAME});
 	}
 
 #	$shash->{STATE} = $myState;

--- a/65_HiveHome_Product.pm
+++ b/65_HiveHome_Product.pm
@@ -6,7 +6,6 @@ use warnings;
 use AttrTemplate;
 use SetExtensions;
 use Data::Dumper;
-#use HiveHome;
 
 sub trim($) { my $s = shift; $s =~ s/^\s+|\s+$//g; return $s };
 sub	toString($) { my ($parameter) = @_; if (defined($parameter)) { return $parameter; } else { return '<undefined>'; } };


### PR DESCRIPTION
Apply the same fix to devices and actions as applied to products.
Remove some unnecessary logic and commented out code.