### PR TITLE
Correct AutoAlias errors

### DIFF
--- a/65_HiveHome_Action.pm
+++ b/65_HiveHome_Action.pm
@@ -118,9 +118,17 @@ sub HiveHome_Action_SetAlias($$)
 	Log(5, "HiveHome_Action_SetAlias: enter");
 
 	my $attVal = AttrVal($name, 'autoAlias', undef);
-	if (defined($attVal) && $attVal eq '1')
+	if (defined($attVal) && $attVal eq '1' && $init_done)
 	{
-		fhem("attr ${name} alias ".InternalVal($name, 'name', ''));
+		my $friendlyName = InternalVal($name, 'name', undef);
+		if (defined($friendlyName))
+		{
+			my $alias = AttrVal($name, 'alias', undef);
+			if (!defined($alias) || $alias ne $friendlyName)
+			{
+				fhem("attr ${name} alias ${friendlyName}");
+			}
+		}
 	}	
 	Log(5, "HiveHome_Action_SetAlias: exit");
 	return undef;
@@ -135,13 +143,17 @@ sub HiveHome_Action_Attr($$$$)
 
 	Log(4, "HiveHome_Action_Attr: Cmd: ${cmd}, Attribute: ${attrName}, value: ${attrVal}");
 
-	if ($attrName eq 'autoAlias') 
+	if ($attrName eq 'autoAlias' && $init_done) 
 	{
         if ($cmd eq 'set')
 		{
 			if ($attrVal eq '1')
 			{
-				fhem("attr ${name} alias ".$hash->{name}.' '.$hash->{productType});
+				my $alias = AttrVal($name, 'alias', undef);
+				if (!defined($alias) || ($alias ne $hash->{name}))
+				{
+					fhem("attr ${name} alias ".$hash->{name});
+				}
 			}
 			else
 			{

--- a/65_HiveHome_Device.pm
+++ b/65_HiveHome_Device.pm
@@ -145,9 +145,18 @@ sub HiveHome_Device_SetAlias($$)
 	Log(5, "HiveHome_Device_SetAlias: enter");
 
 	my $attVal = AttrVal($name, 'autoAlias', undef);
-	if (defined($attVal) && $attVal eq '1')
+	if (defined($attVal) && $attVal eq '1' && $init_done)
 	{
-		fhem("attr ${name} alias ".InternalVal($name, 'name', '').' '.InternalVal($name, 'deviceType', ''));
+		my $friendlyName = InternalVal($name, 'name', undef);
+		my $deviceType = InternalVal($name, 'deviceType', undef);
+		if (defined($friendlyName) && defined($deviceType))
+		{
+			my $alias = AttrVal($name, 'alias', undef);
+			if (!defined($alias) || ($alias ne "${friendlyName} ${deviceType}"))
+			{
+				fhem("attr ${name} alias ${friendlyName} ${deviceType}");
+			}
+		}
 	}
 
 	Log(5, "HiveHome_Device_SetAlias: exit");
@@ -163,13 +172,17 @@ sub HiveHome_Device_Attr($$$$)
 
 	Log(4, "HiveHome_Device_Attr: Cmd: ${cmd}, Attribute: ${attrName}, value: ${attrVal}");
 
-	if ($attrName eq 'autoAlias') 
+	if ($attrName eq 'autoAlias' && $init_done) 
 	{
         if ($cmd eq 'set')
 		{
 			if ($attrVal eq '1')
 			{
-				fhem("attr ${name} alias ".$hash->{name}.' '.$hash->{productType});
+				my $alias = AttrVal($name, 'alias', undef);
+				if (!defined($alias) || ($alias ne $hash->{name}." ".$hash->{productType}))
+				{
+					fhem("attr ${name} alias ".$hash->{name}." ".$hash->{productType});
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Fine tune the autoAlias functionality a bit more to remove errors from the logs when device values have not been set yet and do not update the alias if it is already correctly set. This will stop the save config from showing all the time.