### PR TITLE
Set zone heating schedule based on trv schedule

### DIFF
--- a/65_HiveHome.pm
+++ b/65_HiveHome.pm
@@ -458,12 +458,26 @@ our %ELEMENT_TYPE = (
     ,   TRV => 2
 );
 
+sub _copyDayElement($)
+{
+    my ($dayElement) = @_;
+
+    my $retElement = {
+            element =>  $dayElement->{element}
+        ,   temp =>     $dayElement->{temp}
+        ,   time =>     $dayElement->{time}
+        ,   hour =>     $dayElement->{hour}
+        ,   min =>     $dayElement->{min}
+    };
+    return $retElement;
+}
+
 sub _mergeElement1WithHottestTemperature($$$)
 {
 	my ($elementHeating, $elementTRV, $elementType) = @_;
 
-    # Default is to return elementHeating
-    my $retElement = $elementHeating;
+    # Default is to return a copy of elementHeating
+    my $retElement = _copyDayElement($elementHeating);
 
     if (defined($elementTRV) && $elementTRV->{temp} > $elementHeating->{temp}) {
         $retElement->{temp} = $elementTRV->{temp};

--- a/65_HiveHome.pm
+++ b/65_HiveHome.pm
@@ -537,16 +537,13 @@ sub _mergeDayHeatingShedule($$$$)
 	my ($hiveHomeClient, $day, $heatingDayShedule, $trvDayShedule) = @_;
     my $retDaySchedule = undef;
 
-    if (defined($trvDayShedule))
-    {
+    if (defined($trvDayShedule))  {
         Log(4, "_mergeDayHeatingShedule(${day}) - trv:     ${trvDayShedule}");
 
         # If we have a heating schedule defined for the day
-        if (defined($heatingDayShedule))
-        {
+        if (defined($heatingDayShedule)) {
             # And a string compare does not match
-            if ($heatingDayShedule ne $trvDayShedule)
-            {
+            if ($heatingDayShedule ne $trvDayShedule) {
                 Log(4, "_mergeDayHeatingShedule(${day}) - heating: ${heatingDayShedule}");
 
                 # Breakdown both schedules into their time/temp sections.
@@ -578,10 +575,8 @@ sub _mergeDayHeatingShedule($$$$)
 
                 # Assumption is that TRV from is always equal to or later than Heating from 
                 my $finished = 0;
-                while ($finished == 0)
-                {
-                    if ((defined($heatingElement) && defined($trvElement)) && ($heatingElement->{time} eq $trvElement->{time}))
-                    {
+                while ($finished == 0) {
+                    if ((defined($heatingElement) && defined($trvElement)) && ($heatingElement->{time} eq $trvElement->{time})) {
                         # If both elements are at the same time.
                         # Then add the hotter of the two to the output array.
 
@@ -599,9 +594,7 @@ sub _mergeDayHeatingShedule($$$$)
                         # Get the next TRV element.
                         $trvElement = shift(@trvDayElements);                            
                         $heatingElement = shift(@heatingDayElements);
-                    }
-                    elsif (defined($trvElement) && _is1stTimeBefore2ndTime($trvElement, $heatingElement))
-                    {
+                    } elsif (defined($trvElement) && _is1stTimeBefore2ndTime($trvElement, $heatingElement)) {
                         # If the next element in chronological order is the trvElement
                         if (defined($lastAddedElementType) && $lastAddedElementType == $ELEMENT_TYPE{TRV}) {
                             # If the last added element was also a trv element or its temperature is equal or greater than the previous heating element.
@@ -615,9 +608,7 @@ sub _mergeDayHeatingShedule($$$$)
                         }
                         $trvElementPrevious = $trvElement;
                         $trvElement = shift(@trvDayElements);                            
-                    } 
-                    elsif (defined($heatingElement) && _is1stTimeBefore2ndTime($heatingElement, $trvElement))
-                    {
+                    } elsif (defined($heatingElement) && _is1stTimeBefore2ndTime($heatingElement, $trvElement)) {
                         # If the next element in chronological order is the heatingElement
                         if (defined($lastAddedElementType) && $lastAddedElementType == $ELEMENT_TYPE{HEATING}) {
                             # If the last added element was also a heating element or its temperature is equal or greater than the previous TRV element.
@@ -631,9 +622,7 @@ sub _mergeDayHeatingShedule($$$$)
                         } 
                         $heatingElementPrevious = $heatingElement;
                         $heatingElement = shift(@heatingDayElements);
-                    }
-                    else
-                    {
+                    } else {
                         # No more elements in either array. Time to finish!
                         $finished = 1;
                     }
@@ -641,37 +630,26 @@ sub _mergeDayHeatingShedule($$$$)
 
                 my $maxNumbHeatingElements = (defined($hiveHomeClient)) ? $hiveHomeClient->_getMaxNumbHeatingElements() : 6;
 
-
                 # Check if the new day schedule has the allowed number of elements!
-                if ($maxNumbHeatingElements >= $#retDayElements)
-                {
+                if ($maxNumbHeatingElements >= $#retDayElements) {
                     # The number of day elements are within the allowed range!
                     $retDaySchedule =  join(" / ", map($_->{element},  @retDayElements));
-                }
-                else
-                {
+                } else {
                     # There are too many elements in the day. 
-
                     Log(2, "_mergeDayHeatingShedule(${day}) - Too many elements - ${maxNumbHeatingElements} - original schedule - ".join(" / ", map($_->{element}, @retDayElements)));
                     $retDaySchedule = _reduceNumberOfElements($maxNumbHeatingElements, \@retDayElements);
                     Log(2, "_mergeDayHeatingShedule(${day}) - Modified schedule - ${retDaySchedule}");
                 }
-            }
-            else
-            {
+            } else {
                 # The current heating schedule is good
                 $retDaySchedule = $heatingDayShedule;
             }
-        }
-        # No current heating schedule is defined yet for the day
-        else
-        {
+        } else {
+            # No current heating schedule is defined yet for the day
             # Initialise it...
             $retDaySchedule = $trvDayShedule;
         }
-    }
-    else
-    {
+    } else {
         # No TRV schedule defined, return the current heating schedule for the day.
         $retDaySchedule = $heatingDayShedule;
     }
@@ -718,17 +696,14 @@ sub HiveHome_SetZoneScheduleByZoneTRVSchedules($)
 
     # For each heating products
     my @heatingProducts = _getHeatingProducts('heating', undef);
-	foreach my $heatingProduct (@heatingProducts) 
-	{
+    foreach my $heatingProduct (@heatingProducts) {
         # Get the heating products zone.
 		my $heatingZone = lc(InternalVal($heatingProduct, "zone", undef));
-        if (defined($heatingZone))
-        {
+        if (defined($heatingZone)) {
             Log(4, "HiveHome_SetZoneScheduleByZoneTRVSchedules: Checking zone TRV has been updated: ${heatingProduct}");
 
             # Test to see if a TRV within that heating zone has been modified 
-            if (defined($hashHiveHome->{helper}{$heatingZone}))
-            {
+            if (defined($hashHiveHome->{helper}{$heatingZone})) {
                 Log(1, "HiveHome_SetZoneScheduleByZoneTRVSchedules: Zone TRV has been updated: ${heatingProduct}");
 
                 delete($hashHiveHome->{helper}{$heatingZone});
@@ -739,22 +714,18 @@ sub HiveHome_SetZoneScheduleByZoneTRVSchedules($)
                 Log(1, "HiveHome_SetZoneScheduleByZoneTRVSchedules: No 'hash' found for ${heatingProduct} with id ${id}") if (!defined($id));
 
                 # Test to see if the heating product that controls that zone is configured to have its schedule set by its TRVs
-                if (0 != AttrVal($heatingProduct, 'setScheduleFromTRVs', 0))
-                {
+                if (0 != AttrVal($heatingProduct, 'setScheduleFromTRVs', 0)) {
                     Log(4, "HiveHome_SetZoneScheduleByZoneTRVSchedules: Zone is configured to be set by zone TRVs: ${heatingProduct}");
 
                     my %schedules;
 
                     # Get all unique TRV heating schedules in the heating zone for the current day.
                     my @zoneTRVs = _getHeatingProducts('trvcontrol', $heatingZone);
-                    foreach my $zoneTRV (@zoneTRVs)
-                    {
+                    foreach my $zoneTRV (@zoneTRVs) {
                         Log(4, "HiveHome_SetZoneScheduleByZoneTRVSchedules: TRV is part of zone: ${zoneTRV}");
-                        if (0 != AttrVal($zoneTRV, 'setScheduleFromTRVs', 0))
-                        {
+                        if (0 != AttrVal($zoneTRV, 'setScheduleFromTRVs', 0)) {
                             my $val = InternalVal($zoneTRV, "WeekProfile_${day}", undef);
-                            if (defined($val))
-                            {
+                            if (defined($val)) {
                                 $val =~ s/°C//ig;
                                 $schedules{$val} = 1;
                             }
@@ -772,8 +743,7 @@ sub HiveHome_SetZoneScheduleByZoneTRVSchedules($)
                         # Compare generated schedule with current schedule...
                         my $weekProfileCmdString = undef;
                         my $different = undef;
-                        foreach my $loopDay (@daysofweek) 
-                        {
+                        foreach my $loopDay (@daysofweek) {
                             my $heatingProfile = HiveHome_ConvertUIDayProfileStringToCmdString($hash->{"WeekProfile_${loopDay}"});
                             $heatingProfile =~ s/[.]0//ig;
 
@@ -782,8 +752,7 @@ sub HiveHome_SetZoneScheduleByZoneTRVSchedules($)
 
                                 if (lc($heatingProfile) eq lc($trvProfile)) {
                                     Log(1, "HiveHome_SetZoneScheduleByZoneTRVSchedules: generated profile (${trvProfile}) matches current - ${heatingProfile}");
-                                }
-                                else {
+                                } else {
                                     my $temp = $hash->{"WeekProfile_${loopDay}"};
                                     $temp =~ s/°C//ig;
                                     Log(1, "HiveHome_SetZoneScheduleByZoneTRVSchedules: generated profile (${heatingSchedule}) different to current - ${temp}");
@@ -798,7 +767,7 @@ sub HiveHome_SetZoneScheduleByZoneTRVSchedules($)
                         # TODO: If schedules do not match, then apply new schedule to heating.
                         if (defined($different)) {
                             Log(1, "HiveHome_SetZoneScheduleByZoneTRVSchedules: Complete WeekProfile - ".$weekProfileCmdString);
-#                           my $resp = $hiveHomeClient->_setSchedule(lc($hash->{productType}), $hash->{id}, $weekProfileCmdString);
+                            my $resp = $hiveHomeClient->_setSchedule(lc($hash->{productType}), $hash->{id}, $weekProfileCmdString);
                         } else {
                             Log(1, "HiveHome_SetZoneScheduleByZoneTRVSchedules: WeekProfile not changed from current - ".$weekProfileCmdString);
                         }

--- a/65_HiveHome_Action.pm
+++ b/65_HiveHome_Action.pm
@@ -62,23 +62,23 @@ sub HiveHome_Action_Define($$)
 	#
 	# The logic is a bit screwed up here...
 	# To get the devices internals set so that the Set command works we need to ensure the following are called
-	#	- Hive_Hub_Initialise
-	#	- Hive_Hub_Define (physical device - doesnt set any internals)
+	#	- HiveHome_Initialise
+	#	- HiveHome_Define (physical device - doesnt set any internals)
 	#	- Hive_Initialise (node)
 	#	- Hive_Define
-	#	-   Calls Hive_Hub_UpdateNodes
+	#	-   Calls HiveHome_UpdateNodes
 	#	-		Calls Dispatch for each node which calls --> Hive_Parse
-	# Hive_HubUpdateNodes gets all nodes details even if they havent been defined yet, this causes autocreate requests
+	# HiveHome_UpdateNodes gets all nodes details even if they havent been defined yet, this causes autocreate requests
 	# which in turn cause cannot autocreate as the device already exists.
-	# So added a parameter to Hive_Hub_UpdateNodes which triggers whether to call Dispatch if the node exists (has been defined yet)
+	# So added a parameter to HiveHome_UpdateNodes which triggers whether to call Dispatch if the node exists (has been defined yet)
 	#
 
-	# Need to call Hive_Hub_UpdateNodes....
+	# Need to call HiveHome_UpdateNodes....
 	if (defined($hash->{IODev}{InitNode}))
 	{
 		($hash->{IODev}{InitNode})->($hash->{IODev}, 1);
 
-		if (1 == $init_done) 
+		if ($init_done) 
 		{
 			$attr{$name}{room}  = 'HiveHome';
 			$attr{$name}{icon} = 'file_json-ld2';
@@ -118,7 +118,7 @@ sub HiveHome_Action_SetAlias($$)
 	Log(5, "HiveHome_Action_SetAlias: enter");
 
 	my $attVal = AttrVal($name, 'autoAlias', undef);
-	if (defined($attVal) && $attVal eq '1')
+	if (defined($attVal) && $attVal eq '1' && $init_done)
 	{
 		fhem("attr ${name} alias ".InternalVal($name, 'name', ''));
 	}	
@@ -135,7 +135,7 @@ sub HiveHome_Action_Attr($$$$)
 
 	Log(4, "HiveHome_Action_Attr: Cmd: ${cmd}, Attribute: ${attrName}, value: ${attrVal}");
 
-	if ($attrName eq 'autoAlias') 
+	if ($attrName eq 'autoAlias' && $init_done) 
 	{
         if ($cmd eq 'set')
 		{

--- a/65_HiveHome_Action.pm
+++ b/65_HiveHome_Action.pm
@@ -129,7 +129,7 @@ sub HiveHome_Action_SetAlias($$)
 				fhem("attr ${name} alias ${friendlyName}");
 			}
 		}
-	}	
+	}
 	Log(5, "HiveHome_Action_SetAlias: exit");
 	return undef;
 }

--- a/65_HiveHome_Action.pm
+++ b/65_HiveHome_Action.pm
@@ -120,8 +120,16 @@ sub HiveHome_Action_SetAlias($$)
 	my $attVal = AttrVal($name, 'autoAlias', undef);
 	if (defined($attVal) && $attVal eq '1' && $init_done)
 	{
-		fhem("attr ${name} alias ".InternalVal($name, 'name', ''));
-	}	
+		my $friendlyName = InternalVal($name, 'name', undef);
+		if (defined($friendlyName))
+		{
+			my $alias = AttrVal($name, 'alias', undef);
+			if (!defined($alias) || $alias ne $friendlyName)
+			{
+				fhem("attr ${name} alias ${friendlyName}");
+			}
+		}
+	}
 	Log(5, "HiveHome_Action_SetAlias: exit");
 	return undef;
 }
@@ -141,7 +149,11 @@ sub HiveHome_Action_Attr($$$$)
 		{
 			if ($attrVal eq '1')
 			{
-				fhem("attr ${name} alias ".$hash->{name}.' '.$hash->{productType});
+				my $alias = AttrVal($name, 'alias', undef);
+				if (!defined($alias) || ($alias ne $hash->{name}))
+				{
+					fhem("attr ${name} alias ".$hash->{name});
+				}
 			}
 			else
 			{

--- a/65_HiveHome_Action.pm
+++ b/65_HiveHome_Action.pm
@@ -62,23 +62,23 @@ sub HiveHome_Action_Define($$)
 	#
 	# The logic is a bit screwed up here...
 	# To get the devices internals set so that the Set command works we need to ensure the following are called
-	#	- Hive_Hub_Initialise
-	#	- Hive_Hub_Define (physical device - doesnt set any internals)
+	#	- HiveHome_Initialise
+	#	- HiveHome_Define (physical device - doesnt set any internals)
 	#	- Hive_Initialise (node)
 	#	- Hive_Define
-	#	-   Calls Hive_Hub_UpdateNodes
+	#	-   Calls HiveHome_UpdateNodes
 	#	-		Calls Dispatch for each node which calls --> Hive_Parse
-	# Hive_HubUpdateNodes gets all nodes details even if they havent been defined yet, this causes autocreate requests
+	# HiveHome_UpdateNodes gets all nodes details even if they havent been defined yet, this causes autocreate requests
 	# which in turn cause cannot autocreate as the device already exists.
-	# So added a parameter to Hive_Hub_UpdateNodes which triggers whether to call Dispatch if the node exists (has been defined yet)
+	# So added a parameter to HiveHome_UpdateNodes which triggers whether to call Dispatch if the node exists (has been defined yet)
 	#
 
-	# Need to call Hive_Hub_UpdateNodes....
+	# Need to call HiveHome_UpdateNodes....
 	if (defined($hash->{IODev}{InitNode}))
 	{
 		($hash->{IODev}{InitNode})->($hash->{IODev}, 1);
 
-		if (1 == $init_done) 
+		if ($init_done) 
 		{
 			$attr{$name}{room}  = 'HiveHome';
 			$attr{$name}{icon} = 'file_json-ld2';

--- a/65_HiveHome_Device.pm
+++ b/65_HiveHome_Device.pm
@@ -70,23 +70,23 @@ sub HiveHome_Device_Define
 	#
 	# The logic is a bit screwed up here...
 	# To get the devices internals set so that the Set command works we need to ensure the following are called
-	#	- Hive_Hub_Initialise
-	#	- Hive_Hub_Define (physical device - doesnt set any internals)
+	#	- HiveHome_Initialise
+	#	- HiveHome_Define (physical device - doesnt set any internals)
 	#	- Hive_Initialise (node)
 	#	- Hive_Define
-	#	-   Calls Hive_Hub_UpdateNodes
+	#	-   Calls HiveHome_UpdateNodes
 	#	-		Calls Dispatch for each node which calls --> Hive_Parse
-	# Hive_HubUpdateNodes gets all nodes details even if they havent been defined yet, this causes autocreate requests
+	# HiveHome_UpdateNodes gets all nodes details even if they havent been defined yet, this causes autocreate requests
 	# which in turn cause cannot autocreate as the device already exists.
-	# So added a parameter to Hive_Hub_UpdateNodes which triggers whether to call Dispatch if the node exists (has been defined yet)
+	# So added a parameter to HiveHome_UpdateNodes which triggers whether to call Dispatch if the node exists (has been defined yet)
 	#
 
-	# Need to call Hive_Hub_UpdateNodes....
+	# Need to call HiveHome_UpdateNodes....
 	if (defined($hash->{IODev}{InitNode}))
 	{
 		($hash->{IODev}{InitNode})->($hash->{IODev}, 1);
 
-		if (1 == $init_done) 
+		if ($init_done) 
 		{
 			$attr{$name}{room}  = 'HiveHome';
 			$attr{$name}{autoAlias} = '1';
@@ -145,7 +145,7 @@ sub HiveHome_Device_SetAlias($$)
 	Log(5, "HiveHome_Device_SetAlias: enter");
 
 	my $attVal = AttrVal($name, 'autoAlias', undef);
-	if (defined($attVal) && $attVal eq '1')
+	if (defined($attVal) && $attVal eq '1' && $init_done)
 	{
 		fhem("attr ${name} alias ".InternalVal($name, 'name', '').' '.InternalVal($name, 'deviceType', ''));
 	}
@@ -163,7 +163,7 @@ sub HiveHome_Device_Attr($$$$)
 
 	Log(4, "HiveHome_Device_Attr: Cmd: ${cmd}, Attribute: ${attrName}, value: ${attrVal}");
 
-	if ($attrName eq 'autoAlias') 
+	if ($attrName eq 'autoAlias' && $init_done) 
 	{
         if ($cmd eq 'set')
 		{
@@ -300,10 +300,7 @@ sub HiveHome_Device_Parse($$$)
         }
 
 		readingsBulkUpdate($shash, "state", $myState);
-
-
 		readingsEndUpdate($shash, 1);
-
 
 		HiveHome_Device_SetAlias($shash, $shash->{NAME});
 	}

--- a/65_HiveHome_Device.pm
+++ b/65_HiveHome_Device.pm
@@ -147,7 +147,16 @@ sub HiveHome_Device_SetAlias($$)
 	my $attVal = AttrVal($name, 'autoAlias', undef);
 	if (defined($attVal) && $attVal eq '1' && $init_done)
 	{
-		fhem("attr ${name} alias ".InternalVal($name, 'name', '').' '.InternalVal($name, 'deviceType', ''));
+		my $friendlyName = InternalVal($name, 'name', undef);
+		my $deviceType = InternalVal($name, 'deviceType', undef);
+		if (defined($friendlyName) && defined($deviceType))
+		{
+			my $alias = AttrVal($name, 'alias', undef);
+			if (!defined($alias) || ($alias ne "${friendlyName} ${deviceType}"))
+			{
+				fhem("attr ${name} alias ${friendlyName} ${deviceType}");
+			}
+		}
 	}
 
 	Log(5, "HiveHome_Device_SetAlias: exit");
@@ -169,7 +178,11 @@ sub HiveHome_Device_Attr($$$$)
 		{
 			if ($attrVal eq '1')
 			{
-				fhem("attr ${name} alias ".$hash->{name}.' '.$hash->{productType});
+				my $alias = AttrVal($name, 'alias', undef);
+				if (!defined($alias) || ($alias ne $hash->{name}." ".$hash->{productType}))
+				{
+					fhem("attr ${name} alias ".$hash->{name}." ".$hash->{productType});
+				}
 			}
 			else
 			{

--- a/65_HiveHome_Device.pm
+++ b/65_HiveHome_Device.pm
@@ -70,23 +70,23 @@ sub HiveHome_Device_Define
 	#
 	# The logic is a bit screwed up here...
 	# To get the devices internals set so that the Set command works we need to ensure the following are called
-	#	- Hive_Hub_Initialise
-	#	- Hive_Hub_Define (physical device - doesnt set any internals)
+	#	- HiveHome_Initialise
+	#	- HiveHome_Define (physical device - doesnt set any internals)
 	#	- Hive_Initialise (node)
 	#	- Hive_Define
-	#	-   Calls Hive_Hub_UpdateNodes
+	#	-   Calls HiveHome_UpdateNodes
 	#	-		Calls Dispatch for each node which calls --> Hive_Parse
-	# Hive_HubUpdateNodes gets all nodes details even if they havent been defined yet, this causes autocreate requests
+	# HiveHome_UpdateNodes gets all nodes details even if they havent been defined yet, this causes autocreate requests
 	# which in turn cause cannot autocreate as the device already exists.
-	# So added a parameter to Hive_Hub_UpdateNodes which triggers whether to call Dispatch if the node exists (has been defined yet)
+	# So added a parameter to HiveHome_UpdateNodes which triggers whether to call Dispatch if the node exists (has been defined yet)
 	#
 
-	# Need to call Hive_Hub_UpdateNodes....
+	# Need to call HiveHome_UpdateNodes....
 	if (defined($hash->{IODev}{InitNode}))
 	{
 		($hash->{IODev}{InitNode})->($hash->{IODev}, 1);
 
-		if (1 == $init_done) 
+		if ($init_done) 
 		{
 			$attr{$name}{room}  = 'HiveHome';
 			$attr{$name}{autoAlias} = '1';
@@ -313,10 +313,7 @@ sub HiveHome_Device_Parse($$$)
         }
 
 		readingsBulkUpdate($shash, "state", $myState);
-
-
 		readingsEndUpdate($shash, 1);
-
 
 		HiveHome_Device_SetAlias($shash, $shash->{NAME});
 	}

--- a/65_HiveHome_Product.pm
+++ b/65_HiveHome_Product.pm
@@ -38,6 +38,7 @@ sub HiveHome_Product_Initialize($)
 						. "temperatureOffset:${tempoffsetlist} "
 						. "controlZoneHeating:1,0 "
 						. "controlZoneHeatingMinNumberOfTRVs "
+						. "setScheduleFromTRVs:1,0 "
 						. $readingFnAttributes;
 
 	Log(5, "HiveHome_Product_Initialize: exit");
@@ -114,6 +115,11 @@ sub HiveHome_Product_Define($$)
 		if (lc($productType) eq "heating") {
 			$attr{$name}{controlZoneHeating} = 1 if (!exists($attr{$name}{controlZoneHeating}));
 			$attr{$name}{controlZoneHeatingMinNumberOfTRVs} = 3 if (!exists($attr{$name}{controlZoneHeatingMinNumberOfTRVs}));
+			$attr{$name}{setScheduleFromTRVs} = 0 if (!exists($attr{$name}{setScheduleFromTRVs}));
+		}
+
+		if (lc($productType) eq "trvcontrol") {
+			$attr{$name}{group} = 'HiveHome TRV' if (!exists($attr{$name}{group}));
 		}
 
 		$attr{$name}{autoAlias} = '1' if (!exists($attr{$name}{autoAlias}));
@@ -252,6 +258,10 @@ sub HiveHome_Product_Attr($$$$)
 		# TODO: Only valid for a heating type product.
 		# TODO: Update existing settings. Can wait until the next refresh for details displayed to the screen, 
 		# 		but the current temperature needs to be corrected against the offset.
+	}
+	elsif ($attrName eq 'setScheduleFromTRVs')
+	{
+		# TODO:
 	}
 
 	Log(5, "HiveHome_Product_Attr: exit");

--- a/65_HiveHome_Product.pm
+++ b/65_HiveHome_Product.pm
@@ -731,7 +731,7 @@ sub HiveHome_Product_Notify($$)
 		<li><code>childLock &lt;lock&gt;</code><br><br>
 		Locks or unlocks the trvcontrol, locking the trv stops any tampering of the temperature setting by turning the dial.<br>
 		lock - 0 or 1. 0 to unlock the trv and 1 to lock it.
-		</li><br>
+		</li><br>	
 	</ul>
 	<br><br>
 	<a name="HiveHome_ProductGet"></a>

--- a/65_HiveHome_Product.pm
+++ b/65_HiveHome_Product.pm
@@ -87,25 +87,25 @@ sub HiveHome_Product_Define($$)
 	#
 	# The logic is a bit screwed up here...
 	# To get the devices internals set so that the Set command works we need to ensure the following are called
-	#	- Hive_Hub_Initialise
-	#	- Hive_Hub_Define (physical device - doesnt set any internals)
+	#	- HiveHome_Initialise
+	#	- HiveHome_Define (physical device - doesnt set any internals)
 	#	- Hive_Initialise (node)
 	#	- Hive_Define
-	#	-   Calls Hive_Hub_UpdateNodes
+	#	-   Calls HiveHome_UpdateNodes
 	#	-		Calls Dispatch for each node which calls --> Hive_Parse
-	# Hive_HubUpdateNodes gets all nodes details even if they havent been defined yet, this causes autocreate requests
+	# HiveHome_UpdateNodes gets all nodes details even if they havent been defined yet, this causes autocreate requests
 	# which in turn cause cannot autocreate as the device already exists.
-	# So added a parameter to Hive_Hub_UpdateNodes which triggers whether to call Dispatch if the node exists (has been defined yet)
+	# So added a parameter to HiveHome_UpdateNodes which triggers whether to call Dispatch if the node exists (has been defined yet)
 	#
 
-	# Need to call Hive_Hub_UpdateNodes....
+	# Need to call HiveHome_UpdateNodes....
 	if (defined($hash->{IODev}{InitNode}))
 	{
 		($hash->{IODev}{InitNode})->($hash->{IODev}, 1);
 
 		# Only interested in events from the "global" device for now.
 		$hash->{NOTIFYDEV}	= "global";
-
+		# If the product is a trv, then they are interested when the heating schedule changes.
 		if (lc($productType) eq "trvcontrol")
 		{
 			$hash->{NOTIFYDEV}	.= ",i:TYPE=HiveHome_Product:FILTER=i:productType=heating";
@@ -363,15 +363,21 @@ sub HiveHome_Product_Parse($$$)
 			}
 
 			# This is a hash that needs breaking down...
+			my $weekProfileChanged = undef;
 			my @daysofweek = qw(monday tuesday wednesday thursday friday saturday sunday);
 			foreach my $day (@daysofweek) 
 			{
 				# TODO: need to ensure the schedule temperatures are offset.
-
 				if (!defined($node->{internals}->{schedule}) || !defined($node->{internals}->{schedule}->{$day}) || "" ne $node->{internals}->{schedule}->{$day})
 				{
-					Log(4, "HiveHome_Product_Parse(".$shash->{NAME}."): WeekProfile_${day} - ".$node->{internals}->{schedule}->{$day});
-					SetInternal($shash, "WeekProfile_${day}", $node->{internals}->{schedule}->{$day});
+					if (lc(InternalVal($shash->{NAME}, "WeekProfile_${day}", '')) ne lc($node->{internals}->{schedule}->{$day}))
+					{
+						Log(4, "HiveHome_Product_Parse(".$shash->{NAME}."): WeekProfile_${day} - '".InternalVal($shash->{NAME}, "WeekProfile_${day}", '')."'");
+						Log(4, "HiveHome_Product_Parse(".$shash->{NAME}."): WeekProfile_${day} - '".$node->{internals}->{schedule}->{$day}."'");
+						Log(4, "HiveHome_Product_Parse(".$shash->{NAME}."): WeekProfile_${day} - modified");
+						SetInternal($shash, "WeekProfile_${day}", $node->{internals}->{schedule}->{$day});
+						$weekProfileChanged = 1;
+					}
 				}
 				else
 				{
@@ -403,7 +409,6 @@ sub HiveHome_Product_Parse($$$)
 			SetInternal($shash, 'mountingModeActive',$node->{internals}->{mountingModeActive} ? "true" : "false");
 			SetInternal($shash, 'mountingMode',		$node->{internals}->{mountingMode});
 			SetInternal($shash, 'eui64',			$node->{internals}->{eui64});
-
 
 			if (defined($node->{internals}->{holidayMode}))
 			{
@@ -490,6 +495,18 @@ sub HiveHome_Product_Parse($$$)
 			readingsBulkUpdate($shash, "state", $myState);
 
 			readingsEndUpdate($shash, 1);
+
+
+			if (defined($weekProfileChanged))
+			{
+				Log(4, "HiveHome_Product_Parse(".$shash->{NAME}."): WeekProfile has been modified");
+				# Call the parent (IODev) HiveHome_TRVScheduleModified function.
+				if (defined($shash->{IODev}{TRVScheduleModified}))
+				{
+					Log(4, "HiveHome_Product_Parse(".$shash->{NAME}."): Calling HiveHome...");
+					($shash->{IODev}{TRVScheduleModified})->($shash->{IODev}, $shash);
+				}
+			}			
 		}
 		HiveHome_Product_SetAlias($shash, $shash->{NAME});
 	}
@@ -528,14 +545,9 @@ sub HiveHome_Product_Notify($$)
 
 		HiveHome_Product_SetAlias($own_hash, $ownName);
 	}
-
 	
-	# TODO: If the Heating is boosted then all the trvs in the same zone must also be boosted.
-	#		When the heating reverts back to its original heating mode, the trvs must also revert back to their previous mode.
-	#			trvs and heating store the previous heating mode in:  props->Previous 
 
-	if (	(lc($dev_hash->{TYPE}) eq "hivehome_product" && lc($dev_hash->{productType} eq "heating"))
-		&& 	(lc($own_hash->{TYPE}) eq "hivehome_product" && lc($own_hash->{productType} eq "trvcontrol")))
+	if (lc($dev_hash->{TYPE}) eq "hivehome_product" && lc($own_hash->{TYPE}) eq "hivehome_product")
 	{
 #		my $devFriendlyName = $dev_hash->{name};
 #		my $ownFriendlyName = $own_hash->{name};
@@ -544,44 +556,50 @@ sub HiveHome_Product_Notify($$)
 		# If the TRV is in the same zone as the heating product
 		if (defined($own_hash->{zone}) && defined($dev_hash->{zone}) && lc($own_hash->{zone}) eq lc($dev_hash->{zone}))
 		{
-			# What is the event?
-			foreach my $event (@{$events}) 
+			# If a zone Heating is being boosted then all the trvs in the same zone must also be boosted.
+			# When the heating reverts back to its original heating mode, the trvs must also revert back to their previous mode.
+			# trvs and heating store the previous heating mode in:  props->Previous 
+			if (lc($dev_hash->{productType}) eq "heating" && lc($own_hash->{productType}) eq "trvcontrol")
 			{
-				$event = "" if(!defined($event));
-
-				my ($name, $value) = split(": ", $event, 2);
-				Log(5, "HiveHome_Product_Notify(${ownName}): Event - ${name} Value - ".toString($value));
-
-				# Heating mode has changed
-				if (lc($name) eq 'mode' && defined($value))
+				# What is the event?
+				foreach my $event (@{$events}) 
 				{
-					my $heatingOverride = AttrVal($name, 'HEATING_OVERRIDE', undef);
-					if (defined($heatingOverride) && lc($heatingOverride) eq 'yes')
+					$event = "" if(!defined($event));
+
+					my ($name, $value) = split(": ", $event, 2);
+					Log(5, "HiveHome_Product_Notify(${ownName}): Event - ${name} Value - ".toString($value));
+
+					# Heating mode has changed
+					if (lc($name) eq 'mode' && defined($value))
 					{
-						Log(4, "HiveHome_Product_Notify(${ownName}): HEATING_OVERRIDE attribute set, not changing its heating mode!");
-					}
-					else
-					{
-						# The heating has been boosted!
-						if (lc($value) eq 'boost')
+						my $heatingOverride = AttrVal($name, 'HEATING_OVERRIDE', undef);
+						if (defined($heatingOverride) && lc($heatingOverride) eq 'yes')
 						{
-							my $cmd = "set ${ownName} boost ". ReadingsVal($devName, 'target', 21).' '.InternalNum($devName, 'boost', 30);
-							Log(4, "HiveHome_Product_Notify(${ownName}): ${cmd}");
-							fhem($cmd);
+							Log(4, "HiveHome_Product_Notify(${ownName}): HEATING_OVERRIDE attribute set, not changing its heating mode!");
 						}
 						else
 						{
-							# What is my current mode? If I am boost, then return to schedule
-							my $myMode = lc(ReadingsVal($ownName, 'mode', ''));
-							if ($myMode eq 'boost')
+							# The heating has been boosted!
+							if (lc($value) eq 'boost')
 							{
-								my $cmd = "set ${ownName} ".InternalVal($ownName, 'previousMode', 'schedule');
+								my $cmd = "set ${ownName} boost ". ReadingsVal($devName, 'target', 21).' '.InternalNum($devName, 'boost', 30);
 								Log(4, "HiveHome_Product_Notify(${ownName}): ${cmd}");
 								fhem($cmd);
 							}
+							else
+							{
+								# What is my current mode? If I am boost, then return to schedule
+								my $myMode = lc(ReadingsVal($ownName, 'mode', ''));
+								if ($myMode eq 'boost')
+								{
+									my $cmd = "set ${ownName} ".InternalVal($ownName, 'previousMode', 'schedule');
+									Log(4, "HiveHome_Product_Notify(${ownName}): ${cmd}");
+									fhem($cmd);
+								}
+							}
+							#### TODO
+							## After calling fhem we should force parse to refresh the UI with the change.
 						}
-						#### TODO
-						## After calling fhem we should force parse to refresh the UI with the change.
 					}
 				}
 			}

--- a/65_HiveHome_Product.pm
+++ b/65_HiveHome_Product.pm
@@ -186,13 +186,13 @@ sub HiveHome_Product_SetAlias($$)
 	if (defined($attVal) && $attVal eq '1' && $init_done)
 	{
 		my $friendlyName = InternalVal($name, 'name', undef);
-		my $deviceType = InternalVal($name, 'deviceType', undef);
-		if (defined($friendlyName) && defined($deviceType))
+		my $productType = InternalVal($name, 'productType', undef);
+		if (defined($friendlyName) && defined($productType))
 		{
 			my $alias = AttrVal($name, 'alias', undef);
-			if (!defined($alias) || ($alias ne "${friendlyName} ${deviceType}"))
+			if (!defined($alias) || ($alias ne "${friendlyName} ${productType}"))
 			{
-				fhem("attr ${name} alias ${friendlyName} ${deviceType}");
+				fhem("attr ${name} alias ${friendlyName} ${productType}");
 			}
 		}
 	}

--- a/65_HiveHome_Product.pm
+++ b/65_HiveHome_Product.pm
@@ -185,8 +185,16 @@ sub HiveHome_Product_SetAlias($$)
 	my $attVal = AttrVal($name, 'autoAlias', undef);
 	if (defined($attVal) && $attVal eq '1' && $init_done)
 	{
-		my $cmd = "attr ${name} alias ".InternalVal($name, 'name', '').' '.InternalVal($name, 'productType', '');
-		fhem($cmd);
+		my $friendlyName = InternalVal($name, 'name', undef);
+		my $deviceType = InternalVal($name, 'deviceType', undef);
+		if (defined($friendlyName) && defined($deviceType))
+		{
+			my $alias = AttrVal($name, 'alias', undef);
+			if (!defined($alias) || ($alias ne "${friendlyName} ${deviceType}"))
+			{
+				fhem("attr ${name} alias ${friendlyName} ${deviceType}");
+			}
+		}
 	}
 	Log(5, "HiveHome_Product_SetAlias: exit");
 	return undef;
@@ -207,7 +215,11 @@ sub HiveHome_Product_Attr($$$$)
 		{
 			if ($attrVal eq '1')
 			{
-				fhem("attr ${name} alias ".$hash->{name}.' '.$hash->{productType});
+				my $alias = AttrVal($name, 'alias', undef);
+				if (!defined($alias) || ($alias ne $hash->{name}." ".$hash->{productType}))
+				{
+					fhem("attr ${name} alias ".$hash->{name}." ".$hash->{productType});
+				}
 			}
 			else
 			{

--- a/65_HiveHome_Product.pm
+++ b/65_HiveHome_Product.pm
@@ -110,16 +110,14 @@ sub HiveHome_Product_Define($$)
 		if (lc($productType) eq "trvcontrol")
 		{
 			$hash->{NOTIFYDEV}	.= ",i:TYPE=HiveHome_Product:FILTER=i:productType=heating";
+			$attr{$name}{group} = 'HiveHome TRV' if (!exists($attr{$name}{group}));
+			$attr{$name}{setScheduleFromTRVs} = 0 if (!exists($attr{$name}{setScheduleFromTRVs}));
 		}
 
 		if (lc($productType) eq "heating") {
 			$attr{$name}{controlZoneHeating} = 1 if (!exists($attr{$name}{controlZoneHeating}));
 			$attr{$name}{controlZoneHeatingMinNumberOfTRVs} = 3 if (!exists($attr{$name}{controlZoneHeatingMinNumberOfTRVs}));
 			$attr{$name}{setScheduleFromTRVs} = 0 if (!exists($attr{$name}{setScheduleFromTRVs}));
-		}
-
-		if (lc($productType) eq "trvcontrol") {
-			$attr{$name}{group} = 'HiveHome TRV' if (!exists($attr{$name}{group}));
 		}
 
 		$attr{$name}{autoAlias} = '1' if (!exists($attr{$name}{autoAlias}));
@@ -408,7 +406,6 @@ sub HiveHome_Product_Parse($$$)
 			SetInternal($shash, 'autoBoost',		$node->{internals}->{autoBoost});
 			SetInternal($shash, 'autoBoostTarget',	$node->{internals}->{autoBoostTarget});
 
-
 			SetInternal($shash, 'manufacturer',		$node->{internals}->{manufacturer});
 			SetInternal($shash, 'model',			$node->{internals}->{model});
 			SetInternal($shash, 'power',			$node->{internals}->{power});
@@ -481,6 +478,10 @@ sub HiveHome_Product_Parse($$$)
 				if (lc($node->{internals}->{calibrationStatus}) eq 'calibrating')
 				{
 					$myState .= ' (calibrating)';
+				}
+				elsif (lc($node->{internals}->{calibrationStatus}) eq 'needs calibrating')
+				{
+					$myState .= ' (needs calibrating)';
 				}
 				elsif (lc($node->{internals}->{calibrationStatus}) ne 'calibrated')
 				{
@@ -582,6 +583,8 @@ sub HiveHome_Product_Notify($$)
 					# Heating mode has changed
 					if (lc($name) eq 'mode' && defined($value))
 					{
+						# TODO: Change this attribute.
+						# This is a user attribute, it should not be used here....
 						my $heatingOverride = AttrVal($name, 'HEATING_OVERRIDE', undef);
 						if (defined($heatingOverride) && lc($heatingOverride) eq 'yes')
 						{

--- a/65_HiveHome_Product.pm
+++ b/65_HiveHome_Product.pm
@@ -731,7 +731,22 @@ sub HiveHome_Product_Notify($$)
 		<li><code>childLock &lt;lock&gt;</code><br><br>
 		Locks or unlocks the trvcontrol, locking the trv stops any tampering of the temperature setting by turning the dial.<br>
 		lock - 0 or 1. 0 to unlock the trv and 1 to lock it.
-		</li><br>	
+		</li><br>
+		<a name="calibrate"></a>
+		<li><code>calibrate &lt;state&gt;</code><br><br>
+		Starts or stops the trvcontrol calibration function.<br>
+		state - start or stop. start to start calibrating the trv and stop to stop calibrating if calibrating is in process.
+		</li><br>
+		<a name="valvePosition"></a>
+		<li><code>valvePosition &lt;position&gt;</code><br><br>
+		Does a thing.<br>
+		position - horizontal or vertical.
+		</li><br>
+		<a name="name"></a>
+		<li><code>name &lt;name&gt;</code><br><br>
+		Sets the name of the device.<br>
+		name - a string value representing the new name of the device. 
+		</li><br>
 	</ul>
 	<br><br>
 	<a name="HiveHome_ProductGet"></a>

--- a/Tester.pl
+++ b/Tester.pl
@@ -1,0 +1,330 @@
+#
+use strict;
+use warnings;
+use utf8;
+
+
+
+
+
+
+
+
+
+
+
+sub _extractHeatingElements($)
+{
+	my ($heatingDayShedule) = @_;
+    # Remove the degrees characters from the temperatures...
+    $heatingDayShedule =~ s/°C//ig;
+    # Seperate each time-temp pair.
+    my @heatingDayElements = split(/ \/ /, $heatingDayShedule);
+    my @retDayElements;
+
+    my $lastTemp = undef;
+
+    foreach my $heatingElement (@heatingDayElements) 
+    { 
+        my $hashHeatingElement = {};        
+        # Seperate the time and the temp...
+        $hashHeatingElement->{element} = $heatingElement;
+        my ($heatingTime, $heatingTemp) = split(/-/, $heatingElement);
+        # Put them into a hash and push that into a new array.
+        $hashHeatingElement->{temp} = $heatingTemp;
+        $hashHeatingElement->{time} = $heatingTime;
+        # Seperate the time into hour and mins...
+        my ($heatingHour, $heatingMin) = split(/:/, $heatingTime);
+        $hashHeatingElement->{hour} = $heatingHour;
+        $hashHeatingElement->{min} = $heatingMin;
+        # Push the new hash into our return array.
+        push(@retDayElements, $hashHeatingElement);
+
+        $lastTemp = $heatingTemp;
+    }
+
+    # Add a dummy last entry at the beginning of the following day with the same temperature as the previous entry.
+#    my $hashHeatingElement = {};
+#    $hashHeatingElement->{hour} = 24;
+#    $hashHeatingElement->{min} = 00;
+#    $hashHeatingElement->{temp} = $lastTemp;
+#    $hashHeatingElement->{time} = $hashHeatingElement->{hour}.":".$hashHeatingElement->{min};
+#    $hashHeatingElement->{element} = $hashHeatingElement->{time}."-".$hashHeatingElement->{temp};
+#    # Push the new hash into our return array.
+#    push(@retDayElements, $hashHeatingElement);
+
+    return @retDayElements;
+}
+
+sub _insertNewDayElement($$)
+{
+	my ($dayElements_ref, $element) = @_;
+
+    if (!defined(@{$dayElements_ref}[-1]))
+    {
+        # If the array is empty, just add the passed element to the array
+        push(@{$dayElements_ref}, $element);
+    }
+    else
+    {
+        # The array has some values, lets check to see if the last element has the same temperature, 
+        # only add the new element if the current temp is different to the previous temp
+        if ($dayElements_ref->[-1]->{temp} != $element->{temp})
+        {
+            push(@{$dayElements_ref}, $element);            
+        }
+    }
+}
+
+sub _is1stTimeBefore2ndTime($$) 
+{
+	my ($time1, $time2) = @_;
+    return 1 if ($time1->{hour} < $time2->{hour} || ($time1->{hour} == $time2->{hour} && $time1->{min} < $time2->{min}));
+    return 0;
+}
+
+sub HiveHome_GetWeekDay($)
+{
+	my ($str) = @_;
+
+	my $weekDay=undef;
+	my $timenum;
+
+	if (defined($str)) {
+		my @a = split("[T: -]", $str);
+		$timenum=mktime($a[5],$a[4],$a[3],$a[2],$a[1]-1,$a[0]-1900,0,0,-1);	
+	} else {
+		$timenum=time;
+	}
+
+	my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime($timenum);
+	my @weekdays = qw(monday tuesday wednesday thursday friday saturday sunday);
+	$weekDay = $weekdays[$wday - 1];
+  
+ 	Log(4, "Weekday: ${weekDay}"); 
+  
+	return $weekDay;
+}
+
+sub _mergeDayHeatingShedule($$$$)
+{
+	my ($hiveHomeClient, $day, $heatingDayShedule, $trvDayShedule) = @_;
+    my $retDaySchedule = undef;
+
+    if (defined($trvDayShedule))
+    {
+        Log(4, "_mergeDayHeatingShedule(${day}) - trv:     ${trvDayShedule}");
+
+        # If we have a heating schedule defined for the day
+        if (defined($heatingDayShedule))
+        {
+            # And a string compare does not match
+            if ($heatingDayShedule ne $trvDayShedule)
+            {
+                Log(4, "_mergeDayHeatingShedule(${day}) - heating: ${heatingDayShedule}");
+
+                # Breakdown both schedules into their time/temp sections.
+                # UI schedule looks like - 00:00-15°C / 06:15-20°C / 08:30-15°C / 15:00-20°C / 23:00-15°C / 23:55-15°C
+                # could also have temp with decimals.
+
+                # Convert the heating day schedule to an array of hashes(temp and time).
+                my @heatingDayElements = _extractHeatingElements($heatingDayShedule);
+                my @trvDayElements = _extractHeatingElements($trvDayShedule);
+
+#                Log(1, "Heating ".Dumper(@heatingDayElements));
+#                Log(1, "TRV     ".Dumper(@trvDayElements));
+
+                # Get the first heating and trv elements. These will both be for time 00:00
+                my $trvElementFrom = shift(@trvDayElements);
+                my $heatingElementFrom = shift(@heatingDayElements);
+                my $heatingElementTo = shift(@heatingDayElements);
+
+                # Assumption is that both arrays start from 00:00.
+                my $position = $heatingElementFrom;
+
+                my @retDayElements;
+
+                # Assumption is that TRV from is always equal to or later than Heating from 
+                my $finished = 0;
+                while ($finished == 0)
+                {
+                    if (defined($heatingElementFrom) && defined($trvElementFrom))
+                    {
+                        if ($heatingElementFrom->{time} eq $trvElementFrom->{time})
+                        {
+                            # If the TRV from and heating from times are the same
+
+                            $position = $heatingElementFrom;
+
+                            # Find the hotter of the two elements.
+                            if ($trvElementFrom->{temp} > $heatingElementFrom->{temp})
+                            {
+                                $position->{temp} = $trvElementFrom->{temp};
+                                $position->{element} = $position->{time}."-".$position->{temp};
+                            }
+                            _insertNewDayElement(\@retDayElements, $position);
+
+                            # Get the next TRV element.
+                            $trvElementFrom = shift(@trvDayElements);
+                        }
+                        else 
+                        {
+                            if (defined($heatingElementTo))
+                            {
+                                if (_is1stTimeBefore2ndTime($trvElementFrom, $heatingElementTo))
+                                {
+                                    # If the TRV from time is between heating from and to times
+
+                                    $position = $trvElementFrom;
+                                    if ($heatingElementFrom->{temp} > $trvElementFrom->{temp})
+                                    {
+                                        $position->{temp} = $heatingElementFrom->{temp};
+                                        $position->{element} = $position->{time}."-".$position->{temp};
+                                    }
+                                    _insertNewDayElement(\@retDayElements, $position);
+
+                                    # Get the next TRV elements.
+                                    $trvElementFrom = shift(@trvDayElements);
+                                }
+                                else 
+                                {
+                                    # The TRV from time is after the heating to time.
+
+                                    if ($trvElementFrom->{time} ne $heatingElementTo->{time})
+                                    {
+                                        if ($heatingElementFrom->{temp} > $position->{temp})
+                                        {
+                                            _insertNewDayElement(\@retDayElements, $heatingElementFrom);
+
+                                            if ($position->{temp} > $heatingElementTo->{temp})
+                                            {
+                                                $position->{time} = $heatingElementTo->{time};
+                                                $position->{element} = $position->{time}."-".$position->{temp};
+                                            } else {
+                                                $position = $heatingElementTo;
+                                            }
+                                            _insertNewDayElement(\@retDayElements, $position);
+                                        }
+
+                                        if ($heatingElementTo->{temp} > $position->{temp})
+                                        {
+                                            _insertNewDayElement(\@retDayElements, $heatingElementTo);
+                                            $position = $heatingElementTo;
+                                        }                                        
+                                    }
+                                    
+                                    # Get the next heating element
+                                    $heatingElementFrom = $heatingElementTo;
+                                    $heatingElementTo = shift(@heatingDayElements);
+                                }
+                            }
+                            else
+                            {
+                                # No heating to defined, at the end of the heating array.
+
+                                $position = $trvElementFrom;
+                                if ($trvElementFrom->{temp} >= $heatingElementFrom->{temp})
+                                {
+                                    _insertNewDayElement(\@retDayElements, $position);
+                                }
+
+                                # Get the next TRV elements.
+                                $trvElementFrom = shift(@trvDayElements);
+                            }
+                        }
+                    }
+                    elsif (defined($heatingElementFrom))
+                    {
+                        # If the heating from element is defined.
+                        
+                        if (defined($heatingElementTo) && $heatingElementTo->{temp} > $position->{temp})
+                        {
+                            _insertNewDayElement(\@retDayElements, $heatingElementTo);
+                        }
+
+                        # Get the next heating element
+                        $heatingElementFrom = $heatingElementTo;
+                        $heatingElementTo = shift(@heatingDayElements);                        
+                    }
+                    else
+                    {
+                        # No more elements in either array. Time to finish!
+                        $finished = 1;
+                    }
+                }
+
+                # Check if the new day schedule has the allowed number of elements!
+                if (defined($hiveHomeClient) && $hiveHomeClient->_getMaxNumbHeatingElements() >= $#retDayElements)
+                {
+                    # The number of day elements are within the allowed range!
+                    $retDaySchedule =  join(" / ", map($_->{element},  @retDayElements));
+                }
+                else
+                {
+                    # TODO: There are too many elements in the day.
+                    #       Loop through the elements and merge some of them together
+                    #   
+                    #       Find the two closest elements in time/temp and remove one element and set the temp to the maximum so it covers all TRVS.
+                    #       E.g.    06:30-20 / 07:00-21 / 12:00-19
+                    #       The 6:30 element would need to be changed to 21 and the 07:00 removed.
+                    #               06:30-21 / 12:00-19
+                    #
+                    # The number of day elements are within the allowed range!
+
+                    $retDaySchedule =  join(" / ", map($_->{element},  @retDayElements));
+                    Log(1, "_mergeDayHeatingShedule(${day}) - Too many elements - ${retDaySchedule}");
+                }
+            }
+            else
+            {
+                # The current heating schedule is good
+                $retDaySchedule = $heatingDayShedule;
+            }
+        }
+        # No current heating schedule is defined yet for the day
+        else
+        {
+            # Initialise it...
+            $retDaySchedule = $trvDayShedule;
+        }
+    }
+    else
+    {
+        # No TRV schedule defined, return the current heating schedule for the day.
+        $retDaySchedule = $heatingDayShedule;
+    }
+    Log(4, "_mergeDayHeatingShedule(${day}) - output:  ${retDaySchedule}");
+
+    return $retDaySchedule;
+}
+
+
+sub Log
+{
+    # This subroutine mimics the interface of the FHEM defined Log so that the test does not crash.
+    my $var = '';
+}
+
+
+
+# Get todays shortname
+my @daysofweek = qw(monday tuesday wednesday thursday friday saturday sunday);
+my $day = HiveHome_GetWeekDay(undef);
+
+
+my %schedules;
+$schedules{"00:00-15 / 06:30-21 / 08:00-17 / 15:00-17 / 18:00-21 / 23:00-15"} = 1;
+$schedules{"00:00-15 / 06:15-20 / 08:30-15 / 17:00-20 / 23:00-15 / 23:55-15"} = 1;
+$schedules{"00:00-18 / 06:15-21 / 07:30-17 / 15:00-20 / 18:00-21 / 23:00-17"} = 1;
+$schedules{"00:00-15 / 08:00-20 / 22:00-15"} = 1;
+
+
+my $hiveHomeClient = undef;
+
+# Combine the unique schedules into a single schedule
+my $heatingSchedule;
+foreach my $schedule (keys %schedules) {
+    Log(1, "HiveHome_SetZoneScheduleByZoneTRVSchedules: TRV is part of zone: ${schedule}");
+    $heatingSchedule = _mergeDayHeatingShedule($hiveHomeClient, $day, $heatingSchedule, $schedule);
+}
+

--- a/Tester.pl
+++ b/Tester.pl
@@ -91,15 +91,22 @@ sub HiveHome_GetWeekDay($)
 	return $weekDay;
 }
 
-sub _mergeElement1WithHottestTemperature($$)
-{
-	my ($element1, $element2) = @_;
-    # Default is to return element1
-    my $retElement = $element1;
+our %ELEMENT_TYPE = (
+        HEATING => 1
+    ,   TRV => 2
+);
 
-    if (defined($element2) && $element2->{temp} > $element1->{temp}) {
-        $retElement->{temp} = $element2->{temp};
+sub _mergeElement1WithHottestTemperature($$$)
+{
+	my ($elementHeating, $elementTRV, $elementType) = @_;
+
+    # Default is to return elementHeating
+    my $retElement = $elementHeating;
+
+    if (defined($elementTRV) && $elementTRV->{temp} > $elementHeating->{temp}) {
+        $retElement->{temp} = $elementTRV->{temp};
         $retElement->{element} = $retElement->{time}."-".$retElement->{temp};
+        $_[2] = ($elementType ==  $ELEMENT_TYPE{TRV}) ? $ELEMENT_TYPE{HEATING} : $ELEMENT_TYPE{TRV};
     }
     return $retElement;
 }
@@ -143,11 +150,6 @@ sub _mergeDayHeatingShedule($$$$)
                 # Last added element.
                 my $lastAddedElement = undef;
 
-                my %ELEMENT_TYPE = (
-                        HEATING => 1
-                    ,   TRV => 2
-                );
-
                 # Last element type added.
                 my $lastAddedElementType = undef;
 
@@ -180,22 +182,15 @@ sub _mergeDayHeatingShedule($$$$)
                     elsif (defined($trvElement) && _is1stTimeBefore2ndTime($trvElement, $heatingElement))
                     {
                         # If the next element in chronological order is the trvElement
-                        if (!defined($lastAddedElement) || ($trvElement->{temp} > $lastAddedElement->{temp})) {
+                        if (defined($lastAddedElementType) && $lastAddedElementType == $ELEMENT_TYPE{TRV}) {
+                          # If the last added element was also a trv element or its temperature is equal or greater than the previous heating element.
+                            $lastAddedElement = _mergeElement1WithHottestTemperature($trvElement, $heatingElementPrevious, $lastAddedElementType);
+                            _insertNewDayElement(\@retDayElements, $lastAddedElement);
+                        } elsif (!defined($lastAddedElement) || ($trvElement->{temp} > $lastAddedElement->{temp})) {
                             # If its temperature is greater than the last added element's temperature
                             $lastAddedElement = $trvElement;
                             _insertNewDayElement(\@retDayElements, $lastAddedElement);
                             $lastAddedElementType = $ELEMENT_TYPE{TRV};
-                        } elsif ((defined($lastAddedElementType) && $lastAddedElementType == $ELEMENT_TYPE{TRV})
-                                || ($trvElement->{temp} >= $heatingElementPrevious->{temp})) {
-                           # If the last added element was also a trv element or its temperature is equal or greater than the previous heating element.
-                            $lastAddedElement = $trvElement;
-                            if ($heatingElementPrevious->{temp} > $trvElement->{temp})
-                            {
-                                $lastAddedElement->{temp} = $heatingElementPrevious->{temp};
-                                $lastAddedElement->{element} = $lastAddedElement->{time}."-".$lastAddedElement->{temp};
-                                $lastAddedElementType = $ELEMENT_TYPE{HEATING};
-                            }
-                            _insertNewDayElement(\@retDayElements, $lastAddedElement);
                         }
                         $trvElementPrevious = $trvElement;
                         $trvElement = shift(@trvDayElements);                            
@@ -203,23 +198,16 @@ sub _mergeDayHeatingShedule($$$$)
                     elsif (defined($heatingElement) && _is1stTimeBefore2ndTime($heatingElement, $trvElement))
                     {
                         # If the next element in chronological order is the heatingElement
-                        if (!defined($lastAddedElement) || ($heatingElement->{temp} > $lastAddedElement->{temp})) {
+                        if (defined($lastAddedElementType) && $lastAddedElementType == $ELEMENT_TYPE{HEATING}) {
+                            # If the last added element was also a heating element or its temperature is equal or greater than the previous TRV element.
+                            $lastAddedElement = _mergeElement1WithHottestTemperature($heatingElement, $trvElementPrevious, $lastAddedElementType);
+                            _insertNewDayElement(\@retDayElements, $lastAddedElement);                            
+                        } elsif (!defined($lastAddedElement) || ($heatingElement->{temp} > $lastAddedElement->{temp})) {
                             # If its temperature is greater than the last added element's temperature
                             $lastAddedElement = $heatingElement;
                             _insertNewDayElement(\@retDayElements, $lastAddedElement);
                             $lastAddedElementType = $ELEMENT_TYPE{HEATING};
-                        } elsif ((defined($lastAddedElementType) && $lastAddedElementType == $ELEMENT_TYPE{HEATING})
-                                    || ($heatingElement->{temp} >= $trvElementPrevious->{temp})) {
-                            # If the last added element was also a heating element or its temperature is equal or greater than the previous TRV element.
-                            $lastAddedElement = $heatingElement;
-                            if ($trvElementPrevious->{temp} > $heatingElement->{temp})
-                            {
-                                $lastAddedElement->{temp} = $trvElementPrevious->{temp};
-                                $lastAddedElement->{element} = $lastAddedElement->{time}."-".$lastAddedElement->{temp};
-                                $lastAddedElementType = $ELEMENT_TYPE{TRV};
-                            }
-                            _insertNewDayElement(\@retDayElements, $lastAddedElement);                            
-                        }
+                        } 
                         $heatingElementPrevious = $heatingElement;
                         $heatingElement = shift(@heatingDayElements);
                     }
@@ -311,3 +299,4 @@ foreach my $schedule (keys %schedules) {
     $heatingSchedule = _mergeDayHeatingShedule($hiveHomeClient, $day, $heatingSchedule, $schedule);
 }
 
+print($heatingSchedule);

--- a/Tester.pl
+++ b/Tester.pl
@@ -96,12 +96,26 @@ our %ELEMENT_TYPE = (
     ,   TRV => 2
 );
 
+sub _copyDayElement($)
+{
+    my ($dayElement) = @_;
+
+    my $retElement = {
+            element =>  $dayElement->{element}
+        ,   temp =>     $dayElement->{temp}
+        ,   time =>     $dayElement->{time}
+        ,   hour =>     $dayElement->{hour}
+        ,   min =>     $dayElement->{min}
+    };
+    return $retElement;
+}
+
 sub _mergeElement1WithHottestTemperature($$$)
 {
 	my ($elementHeating, $elementTRV, $elementType) = @_;
 
     # Default is to return elementHeating
-    my $retElement = $elementHeating;
+    my $retElement = _copyDayElement($elementHeating);
 
     if (defined($elementTRV) && $elementTRV->{temp} > $elementHeating->{temp}) {
         $retElement->{temp} = $elementTRV->{temp};
@@ -284,10 +298,17 @@ my %schedules;
 #$schedules{"00:00-15 / 08:00-20 / 22:00-15"} = 1;
 
 # The following does not work!
-$schedules{"00:00-15 / 06:30-20.5 / 08:00-19 / 18:00-20.5 / 23:00-15"} = 1;
-$schedules{"00:00-18 / 06:30-20 / 09:00-19 / 15:00-20 / 18:00-20 / 23:00-17"} = 1;
+#$schedules{"00:00-15 / 06:30-20.5 / 08:00-19 / 18:00-20.5 / 23:00-15"} = 1;
+#$schedules{"00:00-18 / 06:30-20 / 09:00-19 / 15:00-20 / 18:00-20 / 23:00-17"} = 1;
+#$schedules{"00:00-15 / 06:30-20 / 08:00-20 / 18:00-20.5 / 23:00-15"} = 1;
+#$schedules{"00:00-15 / 06:30-20 / 08:00-18 / 18:00-20 / 23:00-15 / 23:55-15"} = 1;
+
+
 $schedules{"00:00-15 / 06:30-20 / 08:00-20 / 18:00-20.5 / 23:00-15"} = 1;
-$schedules{"00:00-15 / 06:30-20 / 08:00-18 / 18:00-20 / 23:00-15 / 23:55-15"} = 1;
+$schedules{"00:00-15 / 07:00-20 / 08:00-18 / 18:00-20 / 23:00-15 / 23:55-15"} = 1;
+$schedules{"00:00-15 / 06:30-20.5 / 08:00-19 / 18:00-20.5 / 23:00-15"} = 1;
+$schedules{"00:00-15 / 07:30-20 / 08:00-20 / 18:00-20.5 / 23:00-18 / 23:55-15"} = 1;
+$schedules{"00:00-18 / 06:30-20.5 / 10:00-19 / 17:00-20.5 / 23:00-17"} = 1;
 
 
 my $hiveHomeClient = undef;

--- a/Tester.pl
+++ b/Tester.pl
@@ -120,7 +120,9 @@ sub _mergeElement1WithHottestTemperature($$$)
     if (defined($elementTRV) && $elementTRV->{temp} > $elementHeating->{temp}) {
         $retElement->{temp} = $elementTRV->{temp};
         $retElement->{element} = $retElement->{time}."-".$retElement->{temp};
-        $_[2] = ($elementType ==  $ELEMENT_TYPE{TRV}) ? $ELEMENT_TYPE{HEATING} : $ELEMENT_TYPE{TRV};
+        if (defined($elementType)) {
+            $_[2] = ($elementType ==  $ELEMENT_TYPE{TRV}) ? $ELEMENT_TYPE{HEATING} : $ELEMENT_TYPE{TRV};
+        }
     }
     return $retElement;
 }
@@ -197,7 +199,7 @@ sub _mergeDayHeatingShedule($$$$)
                     {
                         # If the next element in chronological order is the trvElement
                         if (defined($lastAddedElementType) && $lastAddedElementType == $ELEMENT_TYPE{TRV}) {
-                          # If the last added element was also a trv element or its temperature is equal or greater than the previous heating element.
+                            # If the last added element was also a trv element or its temperature is equal or greater than the previous heating element.
                             $lastAddedElement = _mergeElement1WithHottestTemperature($trvElement, $heatingElementPrevious, $lastAddedElementType);
                             _insertNewDayElement(\@retDayElements, $lastAddedElement);
                         } elsif (!defined($lastAddedElement) || ($trvElement->{temp} > $lastAddedElement->{temp})) {
@@ -232,26 +234,20 @@ sub _mergeDayHeatingShedule($$$$)
                     }
                 }
 
+                my $maxNumbHeatingElements = (defined($hiveHomeClient)) ? $hiveHomeClient->_getMaxNumbHeatingElements() : 6;
+
                 # Check if the new day schedule has the allowed number of elements!
-                if (defined($hiveHomeClient) && $hiveHomeClient->_getMaxNumbHeatingElements() >= $#retDayElements)
+                if ($maxNumbHeatingElements >= $#retDayElements)
                 {
                     # The number of day elements are within the allowed range!
-                    $retDaySchedule =  join(" / ", map($_->{element},  @retDayElements));
+                    $retDaySchedule =  join(" / ", map($_->{element}, @retDayElements));
                 }
                 else
                 {
-                    # TODO: There are too many elements in the day.
-                    #       Loop through the elements and merge some of them together
-                    #   
-                    #       Find the two closest elements in time/temp and remove one element and set the temp to the maximum so it covers all TRVS.
-                    #       E.g.    06:30-20 / 07:00-21 / 12:00-19
-                    #       The 6:30 element would need to be changed to 21 and the 07:00 removed.
-                    #               06:30-21 / 12:00-19
-                    #
-                    # The number of day elements are within the allowed range!
-
-                    $retDaySchedule =  join(" / ", map($_->{element},  @retDayElements));
-                    Log(1, "_mergeDayHeatingShedule(${day}) - Too many elements - ${retDaySchedule}");
+                    # There are too many elements in the day.
+                    Log(2, "_mergeDayHeatingShedule(${day}) - Too many elements - ${maxNumbHeatingElements} - original schedule - ".join(" / ", map($_->{element}, @retDayElements)));
+                    $retDaySchedule = _reduceNumberOfElements($maxNumbHeatingElements, \@retDayElements);
+                    Log(2, "_mergeDayHeatingShedule(${day}) - Modified schedule - ${retDaySchedule}");
                 }
             }
             else
@@ -277,6 +273,52 @@ sub _mergeDayHeatingShedule($$$$)
     return $retDaySchedule;
 }
 
+#       Loop through the elements and merge some of them together
+#   
+#       Find the two closest elements in time/temp and remove one element and set the temp to the maximum so it covers all TRVS.
+#       E.g.    06:30-20 / 07:00-21 / 12:00-19
+#       The 6:30 element would need to be changed to 21 and the 07:00 removed.
+#               06:30-21 / 12:00-19
+sub _reduceNumberOfElements($$) 
+{
+	my ($maxNumbHeatinElements, $dayElements_ref) = @_;
+    my $retDaySchedule = undef;
+
+    my $tempDifference = 0.5;
+    my @retDayElements;
+
+    while ($#{$dayElements_ref} > $maxNumbHeatinElements) 
+    {
+        my $spliced = 0;
+        # Loop through the array looking for elements which are close temperature wise
+        for (my $i=0; $spliced == 0 && $i < $#{$dayElements_ref}; ++$i) {
+
+            # Check to see if the temp elements of the two array items match the current temperature difference.
+            if (abs($dayElements_ref->[$i]->{temp} - $dayElements_ref->[$i+1]->{temp}) <= $tempDifference) {
+
+                # Merge the two elements to create a new element with the hottest temperature
+                $dayElements_ref->[$i] = _mergeElement1WithHottestTemperature($dayElements_ref->[$i], $dayElements_ref->[$i+1], undef);
+                # Remove the second item 
+                splice(@{$dayElements_ref}, $i+1, 1);
+                # Check to see if the following item has the same temperature as the current item
+                if ($i+1 <= $#{$dayElements_ref} && $dayElements_ref->[$i]->{temp} == $dayElements_ref->[$i+1]->{temp}) {
+                    # Remove the second item if so
+                    splice(@{$dayElements_ref}, $i+1, 1);
+                }
+                # Exit the current loop to see if we have reduced the array size enough.
+                $spliced = 1;
+            }
+        }
+
+        if ($spliced == 0) {
+            $tempDifference += 0.5;
+        }
+    }
+
+    $retDaySchedule =  join(" / ", map($_->{element}, (@{$dayElements_ref})));
+
+    return $retDaySchedule;
+}
 
 sub Log
 {
@@ -304,12 +346,15 @@ my %schedules;
 #$schedules{"00:00-15 / 06:30-20 / 08:00-18 / 18:00-20 / 23:00-15 / 23:55-15"} = 1;
 
 
-$schedules{"00:00-15 / 06:30-20 / 08:00-20 / 18:00-20.5 / 23:00-15"} = 1;
-$schedules{"00:00-15 / 07:00-20 / 08:00-18 / 18:00-20 / 23:00-15 / 23:55-15"} = 1;
-$schedules{"00:00-15 / 06:30-20.5 / 08:00-19 / 18:00-20.5 / 23:00-15"} = 1;
-$schedules{"00:00-15 / 07:30-20 / 08:00-20 / 18:00-20.5 / 23:00-18 / 23:55-15"} = 1;
-$schedules{"00:00-18 / 06:30-20.5 / 10:00-19 / 17:00-20.5 / 23:00-17"} = 1;
+#$schedules{"00:00-15 / 06:30-20 / 08:00-20 / 18:00-20.5 / 23:00-15"} = 1;
+#$schedules{"00:00-15 / 07:00-20 / 08:00-18 / 18:00-20 / 23:00-15 / 23:55-15"} = 1;
+#$schedules{"00:00-15 / 06:30-20.5 / 08:00-19 / 18:00-20.5 / 23:00-15"} = 1;
+#$schedules{"00:00-15 / 07:30-20 / 08:00-20 / 18:00-20.5 / 23:00-18 / 23:55-15"} = 1;
+#$schedules{"00:00-18 / 06:30-20.5 / 10:00-19 / 17:00-20.5 / 23:00-17"} = 1;
 
+# Test a schedule with more than the minimum number of events
+$schedules{"00:00-18 / 06:30-21 / 07:00-20 / 07:30-21 / 10:00-19 / 17:00-20.5 / 17:30-20 / 18:00-20.5 / 20:00-19 / 23:00-17"} = 1;
+$schedules{"00:00-18 / 23:00-17"} = 1;
 
 my $hiveHomeClient = undef;
 


### PR DESCRIPTION
Generate the heating zones thermostats schedule based on the TRVs schedule within the same zone.
This functionality is enabled using the 'setScheduleFromTRVs' attribute on the zones heating thermostat. It is also possible to configure which TRVs schedules to use by setting the same attribute on the TRVs.